### PR TITLE
Ensure gh-pages deploy script has write permissions

### DIFF
--- a/.github/workflows/gh-pages-main.yml
+++ b/.github/workflows/gh-pages-main.yml
@@ -3,6 +3,8 @@
 # This workflow will run every time new changes were pushed to the `main` branch
 
 name: App build CI/CD to main branch
+permissions:
+  contents: write
 
 on:
   push:
@@ -34,5 +36,3 @@ jobs:
           force: false
           target-folder: main
           token: ${{ secrets.GH_TOKEN }}
-        permissions:
-          contents: write


### PR DESCRIPTION
Prevents deploy errors on deployment with new version of `JamesIves/github-pages-deploy-action`