### PR TITLE
v1.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@internetarchive/reviews",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/reviews",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@internetarchive/fetch-handler-service": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "license": "AGPL-3.0-only",
   "author": "Internet Archive",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
Bumps version to `1.0.2`, which includes a number of changes to prepare for integration into the details page.