### PR TITLE
v1.0.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@internetarchive/reviews",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/reviews",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@internetarchive/fetch-handler-service": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "license": "AGPL-3.0-only",
   "author": "Internet Archive",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
Bumps the reviews package to `1.0.4`. Includes the transition from displaying just the review form/patron's own review to displaying the full reviews list.