### PR TITLE
v1.0.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@internetarchive/reviews",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/reviews",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@internetarchive/fetch-handler-service": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "license": "AGPL-3.0-only",
   "author": "Internet Archive",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
Bumps version to 1.0.6. Includes a fix for sending itemname as well as screenname when deleting a review.