### PR TITLE
WEBDEV-7652 Update Fetch Handler

### DIFF
--- a/demo/app-root.ts
+++ b/demo/app-root.ts
@@ -12,7 +12,7 @@ import '../src/review';
 import '../src/ia-reviews';
 
 import { MockFetchHandler } from '../test/mocks/mock-fetch-handler';
-import type { FetchHandlerInterface } from '@internetarchive/fetch-handler-service';
+import type { FetchHandlerInterface } from '@internetarchive/fetch-handler';
 import { IaReviews } from '../src/ia-reviews';
 
 @customElement('app-root')

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@internetarchive/reviews",
-  "version": "1.0.6",
+  "version": "1.0.7-webdev-7652.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/reviews",
-      "version": "1.0.6",
+      "version": "1.0.7-webdev-7652.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@internetarchive/fetch-handler": "^1.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@internetarchive/reviews",
-  "version": "1.0.7-webdev-7652.1",
+  "version": "1.0.7-webdev-7652.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/reviews",
-      "version": "1.0.7-webdev-7652.1",
+      "version": "1.0.7-webdev-7652.2",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@internetarchive/fetch-handler": "^1.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@internetarchive/reviews",
-  "version": "1.0.7-webdev-7652.0",
+  "version": "1.0.7-webdev-7652.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/reviews",
-      "version": "1.0.7-webdev-7652.0",
+      "version": "1.0.7-webdev-7652.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@internetarchive/fetch-handler": "^1.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.6",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "@internetarchive/fetch-handler-service": "^1.0.1",
+        "@internetarchive/fetch-handler": "^1.2.0",
         "@internetarchive/ia-activity-indicator": "^0.0.6",
         "@internetarchive/ia-styles": "^1.0.0",
         "@internetarchive/metadata-service": "^1.0.4",
@@ -1065,19 +1065,18 @@
       }
     },
     "node_modules/@internetarchive/analytics-manager": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@internetarchive/analytics-manager/-/analytics-manager-0.1.4.tgz",
-      "integrity": "sha512-2GcEkotsWduirbFoTiNXWzNnzLQArYfJIlW67/alqEKKl95G5jUepYu6FYCd4fj9PwCiPRAp1gDbRSnF9+GsIA==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@internetarchive/analytics-manager/-/analytics-manager-0.1.5.tgz",
+      "integrity": "sha512-6p/EB1ls6x0+xU5WyDcpLU7N4Q1VGW4cNgVV52AUw3nmXJPFZsUM7l7iFGjjJvxWK7TpxU10Z8svAzfdpOQUaA==",
       "license": "AGPL-3.0-only"
     },
-    "node_modules/@internetarchive/fetch-handler-service": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@internetarchive/fetch-handler-service/-/fetch-handler-service-1.0.1.tgz",
-      "integrity": "sha512-6kB8gOU6D3ZcMarZ7xo0F86nbTVEvQvFJuSa7hGKxSJJsNvtfV9tyFXnQSwBVSoQJdL6VOPyzKDOpH77pu60bw==",
+    "node_modules/@internetarchive/fetch-handler": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@internetarchive/fetch-handler/-/fetch-handler-1.2.0.tgz",
+      "integrity": "sha512-gg/Ev46IKRmUmE5TiTrH/AmOsGGn+DBg/B9XmepfKgrn4iW8a/Lg0oHj9qE7NAUxN8dSJ/fYz+Y3R2+LN8cKTg==",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "@internetarchive/analytics-manager": "^0.1.4",
-        "lit": "^2.8.0"
+        "@internetarchive/analytics-manager": "^0.1.5"
       }
     },
     "node_modules/@internetarchive/field-parsers": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "license": "AGPL-3.0-only",
   "author": "Internet Archive",
-  "version": "1.0.7-webdev-7652.1",
+  "version": "1.0.7-webdev-7652.2",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "license": "AGPL-3.0-only",
   "author": "Internet Archive",
-  "version": "1.0.6",
+  "version": "1.0.7-webdev-7652.0",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     ]
   },
   "dependencies": {
-    "@internetarchive/fetch-handler-service": "^1.0.1",
+    "@internetarchive/fetch-handler": "^1.2.0",
     "@internetarchive/ia-activity-indicator": "^0.0.6",
     "@internetarchive/ia-styles": "^1.0.0",
     "@internetarchive/metadata-service": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "license": "AGPL-3.0-only",
   "author": "Internet Archive",
-  "version": "1.0.7-webdev-7652.0",
+  "version": "1.0.7-webdev-7652.1",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "scripts": {

--- a/src/ia-reviews.ts
+++ b/src/ia-reviews.ts
@@ -12,10 +12,7 @@ import { msg } from '@lit/localize';
 
 import type { Review } from '@internetarchive/metadata-service';
 import type { RecaptchaManagerInterface } from '@internetarchive/recaptcha-manager';
-import {
-  FetchHandlerInterface,
-  IaFetchHandler,
-} from '@internetarchive/fetch-handler-service';
+import type { FetchHandlerInterface } from '@internetarchive/fetch-handler';
 import { iaButtonStyles } from '@internetarchive/ia-styles';
 
 import './review';
@@ -80,8 +77,7 @@ export class IaReviews extends LitElement {
   @property({ type: Boolean }) reviewAddEditRequested: boolean = false;
 
   /* An optional handler for form submission to pass along to the form */
-  @property({ type: Object }) fetchHandler: FetchHandlerInterface =
-    new IaFetchHandler();
+  @property({ type: Object }) fetchHandler?: FetchHandlerInterface;
 
   /* Whether to display the review form or the editable review */
   @state()

--- a/src/review-form.ts
+++ b/src/review-form.ts
@@ -38,9 +38,6 @@ export class ReviewForm extends LitElement {
   /* The token for the review edit */
   @property({ type: String }) token: string = '';
 
-  /* The host for archive endpoints and data */
-  @property({ type: String }) baseHost: string = 'https://archive.org';
-
   /* The path for the endpoint we're submitting to */
   @property({ type: String }) endpointPath: string = '/write-review.php';
 
@@ -435,15 +432,12 @@ export class ReviewForm extends LitElement {
       // Indicates to the backend that submission is intended
       formData.append('submitter', 'review-form');
 
-      const result: { success: boolean; error?: string } =
-        await this.fetchHandler.fetchApiResponse(
-          `${this.baseHost}${this.endpointPath}`,
-          {
-            method: 'POST',
-            includeCredentials: true,
-            body: formData,
-          },
-        );
+      const result: { success: boolean; error?: string } | undefined =
+        await this.fetchHandler?.fetchApiPathResponse(this.endpointPath, {
+          method: 'POST',
+          includeCredentials: true,
+          body: formData,
+        });
 
       if (result?.success === true) {
         this.submissionInProgress = false;
@@ -455,7 +449,7 @@ export class ReviewForm extends LitElement {
         });
         this.dispatchEvent(event);
       } else {
-        this.recoverableError = result.error ?? this.GENERIC_ERROR_MESSAGE;
+        this.recoverableError = result?.error ?? this.GENERIC_ERROR_MESSAGE;
         this.stopSubmission();
       }
     } catch (e) {

--- a/src/review-form.ts
+++ b/src/review-form.ts
@@ -19,7 +19,7 @@ import type {
   RecaptchaWidgetInterface,
 } from '@internetarchive/recaptcha-manager';
 import '@internetarchive/ia-activity-indicator';
-import type { FetchHandlerInterface } from '@internetarchive/fetch-handler-service';
+import type { FetchHandlerInterface } from '@internetarchive/fetch-handler';
 import { Review } from '@internetarchive/metadata-service';
 
 import starSelected from './assets/star-selected';

--- a/src/review-form.ts
+++ b/src/review-form.ts
@@ -432,14 +432,14 @@ export class ReviewForm extends LitElement {
       // Indicates to the backend that submission is intended
       formData.append('submitter', 'review-form');
 
-      const result: { success: boolean; error?: string } | undefined =
-        await this.fetchHandler?.fetchApiPathResponse(this.endpointPath, {
+      const result: { success: boolean; error?: string } =
+        await this.fetchHandler.fetchApiPathResponse(this.endpointPath, {
           method: 'POST',
           includeCredentials: true,
           body: formData,
         });
 
-      if (result?.success === true) {
+      if (result.success === true) {
         this.submissionInProgress = false;
         const newReview = this.generateSubmittedReview();
 
@@ -449,7 +449,7 @@ export class ReviewForm extends LitElement {
         });
         this.dispatchEvent(event);
       } else {
-        this.recoverableError = result?.error ?? this.GENERIC_ERROR_MESSAGE;
+        this.recoverableError = result.error ?? this.GENERIC_ERROR_MESSAGE;
         this.stopSubmission();
       }
     } catch (e) {

--- a/test/mocks/mock-fetch-handler.ts
+++ b/test/mocks/mock-fetch-handler.ts
@@ -1,6 +1,10 @@
-import type { FetchHandlerInterface } from '@internetarchive/fetch-handler-service/dist/src/fetch-handler-interface';
+import type { FetchHandlerInterface } from '@internetarchive/fetch-handler';
 
 export class MockFetchHandler implements FetchHandlerInterface {
+  fetchApiPathResponse<T>(): Promise<T> {
+    throw new Error('Method not implemented.');
+  }
+
   async fetchApiResponse<T>(): Promise<T> {
     return { success: true } as T;
   }


### PR DESCRIPTION
Switch `<ia-reviews>` and `<review-form>` to the shared `@internetarchive/fetch-handler` for network requests, so consumers inject one handler (auth, retries, analytics) instead of the component calling `fetch` directly.

- `ia-reviews.ts` / `review-form.ts`: requests routed through the injected `fetchHandler`.
- `test/mocks/mock-fetch-handler.ts`: mock for the new handler; demo updated.
- Published as prerelease `1.0.7-webdev-7652.x` for integration testing.

[WEBDEV-7652](https://webarchive.jira.com/browse/WEBDEV-7652)


[WEBDEV-7652]: https://webarchive.jira.com/browse/WEBDEV-7652?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ