### PR TITLE
WEBDEV-8590 Use CSRF token for review deletion

### DIFF
--- a/src/ia-reviews.ts
+++ b/src/ia-reviews.ts
@@ -270,7 +270,6 @@ export class IaReviews extends LitElement {
       .review=${review}
       .identifier=${this.identifier}
       .baseHost=${this.baseHost}
-      .fetchHandler=${this.fetchHandler}
       .csrfToken=${this.token}
       ?canDelete=${this.canDelete}
       ?bypassTruncation=${this.displayReviewsByDefault}

--- a/src/ia-reviews.ts
+++ b/src/ia-reviews.ts
@@ -269,9 +269,11 @@ export class IaReviews extends LitElement {
     return html`<ia-review
       .review=${review}
       .identifier=${this.identifier}
+      .baseHost=${this.baseHost}
+      .fetchHandler=${this.fetchHandler}
+      .csrfToken=${this.token}
       ?canDelete=${this.canDelete}
       ?bypassTruncation=${this.displayReviewsByDefault}
-      .baseHost=${this.baseHost}
     ></ia-review>`;
   }
 

--- a/src/review.ts
+++ b/src/review.ts
@@ -11,6 +11,7 @@ import { msg } from '@lit/localize';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 
 import { Review } from '@internetarchive/metadata-service';
+import type { FetchHandlerInterface } from '@internetarchive/fetch-handler-service';
 
 import starBasic from './assets/star-basic';
 import { truncateScreenname } from './utils/truncate-screenname';
@@ -40,6 +41,12 @@ export class IaReview extends LitElement {
 
   /* Base for URLs */
   @property({ type: String }) baseHost = 'https://archive.org';
+
+  /* Fetch handler to use for delete request submission */
+  @property({ type: Object }) fetchHandler?: FetchHandlerInterface;
+
+  /* CSRF token to use for delete request submission */
+  @property({ type: String }) csrfToken?: string = '';
 
   /* Whether the person viewing this review has the power to delete it */
   @property({ type: Boolean }) canDelete = false;
@@ -241,7 +248,17 @@ export class IaReview extends LitElement {
 
     const deleteUrl = `${this.baseHost}/edit-reviews.php?identifier=${this.identifier}&deleteReviewer=${this.review.reviewer}&deleteReviewerItemname=${this.review.reviewer_itemname}`;
     try {
-      await fetch(deleteUrl, { method: 'POST' });
+      await this.fetchHandler?.fetchApiResponse(deleteUrl, {
+        includeCredentials: true,
+        method: 'POST',
+        body: JSON.stringify({
+          identifier: this.identifier,
+          deleteReviewer: this.review.reviewer,
+          deleteReviewerItemname: this.review.reviewer_itemname,
+          csrf_token: this.csrfToken,
+        }),
+      });
+
       this.deleteMsg = 'This review has been queued for deletion.';
     } catch {
       this.deleteMsg = 'Sorry, we were unable to delete this review.';

--- a/src/review.ts
+++ b/src/review.ts
@@ -42,9 +42,6 @@ export class IaReview extends LitElement {
   /* Base for URLs */
   @property({ type: String }) baseHost = 'https://archive.org';
 
-  /* Fetch handler to use for delete request submission */
-  @property({ type: Object }) fetchHandler?: FetchHandlerInterface;
-
   /* CSRF token to use for delete request submission */
   @property({ type: String }) csrfToken?: string = '';
 
@@ -246,17 +243,10 @@ export class IaReview extends LitElement {
     if (!this.review || !this.identifier) return;
     if (!confirm(msg('Are you sure you want to delete this review?'))) return;
 
-    const deleteUrl = `${this.baseHost}/edit-reviews.php`;
+    const deleteUrl = `${this.baseHost}/edit-reviews.php?identifier=${this.identifier}&deleteReviewer=${this.review.reviewer}&deleteReviewerItemname=${this.review.reviewer_itemname}&csrf_token=${this.csrfToken}`;
     try {
-      await this.fetchHandler?.fetchApiResponse(deleteUrl, {
-        includeCredentials: true,
+      await fetch(deleteUrl, {
         method: 'POST',
-        body: JSON.stringify({
-          identifier: this.identifier,
-          deleteReviewer: this.review.reviewer,
-          deleteReviewerItemname: this.review.reviewer_itemname,
-          csrf_token: this.csrfToken,
-        }),
       });
 
       this.deleteMsg = 'This review has been queued for deletion.';

--- a/src/review.ts
+++ b/src/review.ts
@@ -11,7 +11,6 @@ import { msg } from '@lit/localize';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 
 import { Review } from '@internetarchive/metadata-service';
-import type { FetchHandlerInterface } from '@internetarchive/fetch-handler-service';
 
 import starBasic from './assets/star-basic';
 import { truncateScreenname } from './utils/truncate-screenname';
@@ -43,7 +42,7 @@ export class IaReview extends LitElement {
   @property({ type: String }) baseHost = 'https://archive.org';
 
   /* CSRF token to use for delete request submission */
-  @property({ type: String }) csrfToken?: string = '';
+  @property({ type: String }) csrfToken: string = '';
 
   /* Whether the person viewing this review has the power to delete it */
   @property({ type: Boolean }) canDelete = false;

--- a/src/review.ts
+++ b/src/review.ts
@@ -246,7 +246,7 @@ export class IaReview extends LitElement {
     if (!this.review || !this.identifier) return;
     if (!confirm(msg('Are you sure you want to delete this review?'))) return;
 
-    const deleteUrl = `${this.baseHost}/edit-reviews.php?identifier=${this.identifier}&deleteReviewer=${this.review.reviewer}&deleteReviewerItemname=${this.review.reviewer_itemname}`;
+    const deleteUrl = `${this.baseHost}/edit-reviews.php`;
     try {
       await this.fetchHandler?.fetchApiResponse(deleteUrl, {
         includeCredentials: true,


### PR DESCRIPTION
Switches the review deletion request to use the fetch handler, and adds a CSRF token, which should soon be required as part of the deletion request.