### PR TITLE
WEBDEV-8840: Put the review network calls behind an injectable service

### DIFF
--- a/demo/app-root.ts
+++ b/demo/app-root.ts
@@ -12,7 +12,8 @@ import '../src/review';
 import '../src/ia-reviews';
 
 import { MockFetchHandler } from '../test/mocks/mock-fetch-handler';
-import type { FetchHandlerInterface } from '@internetarchive/fetch-handler-service';
+import { ReviewService } from '../src/services/review-service';
+import type { ReviewServiceInterface } from '../src/services/review-service-interface';
 import { IaReviews } from '../src/ia-reviews';
 
 @customElement('app-root')
@@ -80,7 +81,10 @@ export class AppRoot extends LitElement {
     }),
   ];
 
-  private fetchHandler: FetchHandlerInterface = new MockFetchHandler();
+  /* Stubs the network so the demo can submit without a backend */
+  private reviewService: ReviewServiceInterface = new ReviewService({
+    fetchHandler: new MockFetchHandler(),
+  });
 
   private mockRecaptchaManager: RecaptchaManagerInterface =
     new RecaptchaManager({
@@ -169,7 +173,7 @@ export class AppRoot extends LitElement {
             : undefined}
           .maxSubjectLength=${this.useCharCounts ? 100 : undefined}
           .maxBodyLength=${this.useCharCounts ? 1000 : undefined}
-          .fetchHandler=${this.fetchHandler}
+          .reviewService=${this.reviewService}
           ?canDelete=${this.allowDeletion}
           ?bypassRecaptcha=${this.bypassRecaptcha}
           ?reviewsDisabled=${this.reviewsDisabled}

--- a/index.ts
+++ b/index.ts
@@ -1,2 +1,11 @@
 export { ReviewForm } from './src/review-form';
 export { IaReviews } from './src/ia-reviews';
+export { IaReview } from './src/review';
+export { ReviewService } from './src/services/review-service';
+export type { ReviewServiceOptions } from './src/services/review-service';
+export type {
+  ReviewDeletion,
+  ReviewServiceInterface,
+  ReviewServiceResult,
+  ReviewSubmission,
+} from './src/services/review-service-interface';

--- a/index.ts
+++ b/index.ts
@@ -2,10 +2,7 @@ export { ReviewForm } from './src/review-form';
 export { IaReviews } from './src/ia-reviews';
 export { IaReview } from './src/review';
 export { ReviewService } from './src/services/review-service';
-export type {
-  ReviewFetchHandler,
-  ReviewServiceOptions,
-} from './src/services/review-service';
+export type { ReviewServiceOptions } from './src/services/review-service';
 export type {
   ReviewDeletion,
   ReviewServiceInterface,

--- a/index.ts
+++ b/index.ts
@@ -2,7 +2,10 @@ export { ReviewForm } from './src/review-form';
 export { IaReviews } from './src/ia-reviews';
 export { IaReview } from './src/review';
 export { ReviewService } from './src/services/review-service';
-export type { ReviewServiceOptions } from './src/services/review-service';
+export type {
+  ReviewFetchHandler,
+  ReviewServiceOptions,
+} from './src/services/review-service';
 export type {
   ReviewDeletion,
   ReviewServiceInterface,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@internetarchive/reviews",
-  "version": "1.1.0-webdev-8840.0",
+  "version": "1.1.0-webdev-8840.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/reviews",
-      "version": "1.1.0-webdev-8840.0",
+      "version": "1.1.0-webdev-8840.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@internetarchive/fetch-handler-service": "^1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@internetarchive/reviews",
-  "version": "1.0.7",
+  "version": "1.1.0-webdev-8840.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/reviews",
-      "version": "1.0.7",
+      "version": "1.1.0-webdev-8840.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@internetarchive/fetch-handler-service": "^1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@internetarchive/reviews",
-  "version": "1.1.0-webdev-8840.1",
+  "version": "1.1.0-webdev-8840.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/reviews",
-      "version": "1.1.0-webdev-8840.1",
+      "version": "1.1.0-webdev-8840.2",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "@internetarchive/fetch-handler-service": "^1.0.1",
+        "@internetarchive/fetch-handler": "^1.3.0",
         "@internetarchive/ia-activity-indicator": "^0.0.6",
         "@internetarchive/ia-styles": "^1.0.0",
         "@internetarchive/metadata-service": "^1.0.4",
@@ -1065,19 +1065,18 @@
       }
     },
     "node_modules/@internetarchive/analytics-manager": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@internetarchive/analytics-manager/-/analytics-manager-0.1.4.tgz",
-      "integrity": "sha512-2GcEkotsWduirbFoTiNXWzNnzLQArYfJIlW67/alqEKKl95G5jUepYu6FYCd4fj9PwCiPRAp1gDbRSnF9+GsIA==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@internetarchive/analytics-manager/-/analytics-manager-0.1.5.tgz",
+      "integrity": "sha512-6p/EB1ls6x0+xU5WyDcpLU7N4Q1VGW4cNgVV52AUw3nmXJPFZsUM7l7iFGjjJvxWK7TpxU10Z8svAzfdpOQUaA==",
       "license": "AGPL-3.0-only"
     },
-    "node_modules/@internetarchive/fetch-handler-service": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@internetarchive/fetch-handler-service/-/fetch-handler-service-1.0.1.tgz",
-      "integrity": "sha512-6kB8gOU6D3ZcMarZ7xo0F86nbTVEvQvFJuSa7hGKxSJJsNvtfV9tyFXnQSwBVSoQJdL6VOPyzKDOpH77pu60bw==",
+    "node_modules/@internetarchive/fetch-handler": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@internetarchive/fetch-handler/-/fetch-handler-1.3.0.tgz",
+      "integrity": "sha512-gvLttOK1xHsRjyBMlYGrlKJwhy4BnYqocrEJDoSCw5Ffe0MdVShCRtljFGNZMRgL3OB7LdPhDRFnBNntWYppJQ==",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "@internetarchive/analytics-manager": "^0.1.4",
-        "lit": "^2.8.0"
+        "@internetarchive/analytics-manager": "^0.1.5"
       }
     },
     "node_modules/@internetarchive/field-parsers": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "license": "AGPL-3.0-only",
   "author": "Internet Archive",
-  "version": "1.0.7",
+  "version": "1.1.0-webdev-8840.0",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "license": "AGPL-3.0-only",
   "author": "Internet Archive",
-  "version": "1.1.0-webdev-8840.0",
+  "version": "1.1.0-webdev-8840.1",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "license": "AGPL-3.0-only",
   "author": "Internet Archive",
-  "version": "1.1.0-webdev-8840.1",
+  "version": "1.1.0-webdev-8840.2",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "scripts": {
@@ -68,7 +68,7 @@
     ]
   },
   "dependencies": {
-    "@internetarchive/fetch-handler-service": "^1.0.1",
+    "@internetarchive/fetch-handler": "^1.3.0",
     "@internetarchive/ia-activity-indicator": "^0.0.6",
     "@internetarchive/ia-styles": "^1.0.0",
     "@internetarchive/metadata-service": "^1.0.4",

--- a/src/ia-reviews.ts
+++ b/src/ia-reviews.ts
@@ -18,6 +18,9 @@ import {
 } from '@internetarchive/fetch-handler-service';
 import { iaButtonStyles } from '@internetarchive/ia-styles';
 
+import type { ReviewServiceInterface } from './services/review-service-interface';
+import { ReviewService } from './services/review-service';
+
 import './review';
 import './review-form';
 
@@ -79,9 +82,22 @@ export class IaReviews extends LitElement {
   /* Whether the add/edit button has been clicked */
   @property({ type: Boolean }) reviewAddEditRequested: boolean = false;
 
-  /* An optional handler for form submission to pass along to the form */
+  /* Handles retries, and for consumers that configure it, the CSRF header */
   @property({ type: Object }) fetchHandler: FetchHandlerInterface =
     new IaFetchHandler();
+
+  /**
+   * Handles the review write and delete requests.
+   *
+   * Leave unset to get a default built from `fetchHandler`, `baseHost`, `endpointPath`, and
+   * `token`, which is what attribute-only consumers rely on. Supply one to control the endpoint
+   * paths and verbs, or to source the CSRF token somewhere else.
+   */
+  @property({ type: Object }) reviewService?: ReviewServiceInterface;
+
+  /* The service the components actually call, whether injected or built here */
+  @state()
+  private activeReviewService?: ReviewServiceInterface;
 
   /* Whether to display the review form or the editable review */
   @state()
@@ -131,6 +147,24 @@ export class IaReviews extends LitElement {
   }
 
   protected willUpdate(changed: PropertyValues): void {
+    const serviceInputsChanged =
+      changed.has('reviewService') ||
+      changed.has('fetchHandler') ||
+      changed.has('baseHost') ||
+      changed.has('endpointPath') ||
+      changed.has('token');
+
+    if (!this.activeReviewService || serviceInputsChanged) {
+      this.activeReviewService =
+        this.reviewService ??
+        new ReviewService({
+          fetchHandler: this.fetchHandler,
+          baseHost: this.baseHost,
+          submitPath: this.endpointPath,
+          csrfToken: this.token,
+        });
+    }
+
     if (changed.has('reviews') || changed.has('submitterItemname')) {
       this.reviewsCount = this.reviews.length;
       this.sortFilterReviews();
@@ -214,15 +248,12 @@ export class IaReviews extends LitElement {
         : html`<ia-review-form
             .identifier=${this.identifier}
             .oldReview=${this.currentReview}
-            .baseHost=${this.baseHost}
-            .endpointPath=${this.endpointPath}
             .submitterItemname=${this.submitterItemname}
             .submitterScreenname=${this.submitterScreenname}
             .maxSubjectLength=${this.maxSubjectLength}
             .maxBodyLength=${this.maxBodyLength}
-            .token=${this.token}
             .unrecoverableError=${this.reviewSubmissionError}
-            .fetchHandler=${this.fetchHandler}
+            .reviewService=${this.activeReviewService}
             .recaptchaManager=${this.recaptchaActivated
               ? this.recaptchaManager
               : undefined}
@@ -270,7 +301,7 @@ export class IaReviews extends LitElement {
       .review=${review}
       .identifier=${this.identifier}
       .baseHost=${this.baseHost}
-      .csrfToken=${this.token}
+      .reviewService=${this.activeReviewService}
       ?canDelete=${this.canDelete}
       ?bypassTruncation=${this.displayReviewsByDefault}
     ></ia-review>`;

--- a/src/ia-reviews.ts
+++ b/src/ia-reviews.ts
@@ -12,10 +12,6 @@ import { msg } from '@lit/localize';
 
 import type { Review } from '@internetarchive/metadata-service';
 import type { RecaptchaManagerInterface } from '@internetarchive/recaptcha-manager';
-import {
-  FetchHandlerInterface,
-  IaFetchHandler,
-} from '@internetarchive/fetch-handler-service';
 import { iaButtonStyles } from '@internetarchive/ia-styles';
 
 import type { ReviewServiceInterface } from './services/review-service-interface';
@@ -54,16 +50,10 @@ export class IaReviews extends LitElement {
   /* Maximum allowable length for body */
   @property({ type: Number }) maxBodyLength?: number;
 
-  /* Base for URLs */
+  /* Base for URLs. Also used for the reviewer profile links. */
   @property({ type: String }) baseHost = 'https://archive.org';
 
   /** REVIEW FORM PROPERTIES */
-  /* The token for the review edit */
-  @property({ type: String }) token: string = '';
-
-  /* The path for the endpoint we're submitting to */
-  @property({ type: String }) endpointPath: string = '/write-review.php';
-
   /** Form submitter's screenname, if applicable */
   @property({ type: String }) submitterScreenname: string = 'Anonymous';
 
@@ -82,16 +72,11 @@ export class IaReviews extends LitElement {
   /* Whether the add/edit button has been clicked */
   @property({ type: Boolean }) reviewAddEditRequested: boolean = false;
 
-  /* Handles retries, and for consumers that configure it, the CSRF header */
-  @property({ type: Object }) fetchHandler: FetchHandlerInterface =
-    new IaFetchHandler();
-
   /**
    * Handles the review write and delete requests.
    *
-   * Leave unset to get a default built from `fetchHandler`, `baseHost`, `endpointPath`, and
-   * `token`, which is what attribute-only consumers rely on. Supply one to control the endpoint
-   * paths and verbs, or to source the CSRF token somewhere else.
+   * Writing and deleting need one, since the service is what carries the CSRF token. Left unset,
+   * reviews still render and the form still opens, but a submission reports a generic failure.
    */
   @property({ type: Object }) reviewService?: ReviewServiceInterface;
 
@@ -147,22 +132,15 @@ export class IaReviews extends LitElement {
   }
 
   protected willUpdate(changed: PropertyValues): void {
-    const serviceInputsChanged =
+    if (
+      !this.activeReviewService ||
       changed.has('reviewService') ||
-      changed.has('fetchHandler') ||
-      changed.has('baseHost') ||
-      changed.has('endpointPath') ||
-      changed.has('token');
-
-    if (!this.activeReviewService || serviceInputsChanged) {
+      changed.has('baseHost')
+    ) {
+      // the fallback keeps rendering and the form working for a consumer that supplies no
+      // service; it carries no CSRF token, so a submission through it fails
       this.activeReviewService =
-        this.reviewService ??
-        new ReviewService({
-          fetchHandler: this.fetchHandler,
-          baseHost: this.baseHost,
-          submitPath: this.endpointPath,
-          csrfToken: this.token,
-        });
+        this.reviewService ?? new ReviewService({ baseHost: this.baseHost });
     }
 
     if (changed.has('reviews') || changed.has('submitterItemname')) {

--- a/src/review-form.ts
+++ b/src/review-form.ts
@@ -19,8 +19,9 @@ import type {
   RecaptchaWidgetInterface,
 } from '@internetarchive/recaptcha-manager';
 import '@internetarchive/ia-activity-indicator';
-import type { FetchHandlerInterface } from '@internetarchive/fetch-handler-service';
 import { Review } from '@internetarchive/metadata-service';
+
+import type { ReviewServiceInterface } from './services/review-service-interface';
 
 import starSelected from './assets/star-selected';
 import starUnselected from './assets/star-unselected';
@@ -34,15 +35,6 @@ import './review';
 export class ReviewForm extends LitElement {
   /* The IA item being reviewed */
   @property({ type: String }) identifier?: string;
-
-  /* The token for the review edit */
-  @property({ type: String }) token: string = '';
-
-  /* The host for archive endpoints and data */
-  @property({ type: String }) baseHost: string = 'https://archive.org';
-
-  /* The path for the endpoint we're submitting to */
-  @property({ type: String }) endpointPath: string = '/write-review.php';
 
   /** Form submitter's screenname, if applicable */
   @property({ type: String }) submitterScreenname: string = 'Anonymous';
@@ -62,8 +54,8 @@ export class ReviewForm extends LitElement {
   /* Optional max length for review body */
   @property({ type: Number }) maxBodyLength?: number;
 
-  /* Handler for form submission */
-  @property({ type: Object }) fetchHandler?: FetchHandlerInterface;
+  /* Handles the review submission request */
+  @property({ type: Object }) reviewService?: ReviewServiceInterface;
 
   /* Service for activating the recaptcha challenge */
   @property({ type: Object }) recaptchaManager?: RecaptchaManagerInterface;
@@ -116,7 +108,7 @@ export class ReviewForm extends LitElement {
         : html`
             <span class="inputs">
               ${this.starsInputTemplate} ${this.subjectInputTemplate}
-              ${this.bodyInputTemplate} ${this.hiddenInputsTemplate}
+              ${this.bodyInputTemplate}
             </span>
           `}
       ${this.recaptchaMessageTemplate} ${this.recoverableErrorTemplate}
@@ -310,20 +302,6 @@ export class ReviewForm extends LitElement {
     `;
   }
 
-  /** Hidden inputs we use to store other information for form submission */
-  private get hiddenInputsTemplate(): HTMLTemplateResult {
-    return html`
-      <input type="hidden" name="field_reviewtoken" .value=${this.token} />
-      ${this.identifier
-        ? html`<input
-            type="hidden"
-            name="identifier"
-            .value=${this.identifier}
-          />`
-        : nothing}
-    `;
-  }
-
   /** Buttons to render at bottom of form */
   private get actionButtonsTemplate(): HTMLTemplateResult {
     return html`<div class="action-btns">
@@ -413,37 +391,25 @@ export class ReviewForm extends LitElement {
       return this.stopSubmission();
     }
 
-    if (!this.fetchHandler) {
+    if (!this.reviewService || !this.identifier) {
       this.recoverableError = this.GENERIC_ERROR_MESSAGE;
       return this.stopSubmission();
     }
 
     try {
-      const formData = new URLSearchParams();
-
+      let recaptchaToken: string | undefined;
       if (!this.bypassRecaptcha) {
-        const recaptchaToken = await this.getRecaptchaToken();
+        recaptchaToken = await this.getRecaptchaToken();
         if (!recaptchaToken) return this.handleRecaptchaError();
-
-        formData.append('g-recaptcha-response', recaptchaToken ?? '');
       }
 
-      for (const entry of new FormData(this.reviewForm)) {
-        formData.append(entry[0], entry[1] as string);
-      }
-
-      // Indicates to the backend that submission is intended
-      formData.append('submitter', 'review-form');
-
-      const result: { success: boolean; error?: string } =
-        await this.fetchHandler.fetchApiResponse(
-          `${this.baseHost}${this.endpointPath}`,
-          {
-            method: 'POST',
-            includeCredentials: true,
-            body: formData,
-          },
-        );
+      const result = await this.reviewService.submitReview({
+        identifier: this.identifier,
+        title: this.reviewForm.field_reviewtitle.value,
+        body: this.reviewForm.field_reviewbody.value,
+        stars: this.reviewForm.field_stars.value,
+        recaptchaToken,
+      });
 
       if (result?.success === true) {
         this.submissionInProgress = false;

--- a/src/review.ts
+++ b/src/review.ts
@@ -12,6 +12,8 @@ import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 
 import { Review } from '@internetarchive/metadata-service';
 
+import type { ReviewServiceInterface } from './services/review-service-interface';
+
 import starBasic from './assets/star-basic';
 import { truncateScreenname } from './utils/truncate-screenname';
 import sanitizeReviewBody from './utils/sanitize-review-body';
@@ -41,8 +43,8 @@ export class IaReview extends LitElement {
   /* Base for URLs */
   @property({ type: String }) baseHost = 'https://archive.org';
 
-  /* CSRF token to use for delete request submission */
-  @property({ type: String }) csrfToken: string = '';
+  /* Handles the review deletion request */
+  @property({ type: Object }) reviewService?: ReviewServiceInterface;
 
   /* Whether the person viewing this review has the power to delete it */
   @property({ type: Boolean }) canDelete = false;
@@ -239,19 +241,23 @@ export class IaReview extends LitElement {
    * Deletes the review, following an extra confirmation.
    */
   private async deleteReview(): Promise<void> {
-    if (!this.review || !this.identifier) return;
+    if (!this.review?.reviewer || !this.identifier) return;
     if (!confirm(msg('Are you sure you want to delete this review?'))) return;
 
-    const deleteUrl = `${this.baseHost}/edit-reviews.php?identifier=${this.identifier}&deleteReviewer=${this.review.reviewer}&deleteReviewerItemname=${this.review.reviewer_itemname}&csrf_token=${this.csrfToken}`;
-    try {
-      await fetch(deleteUrl, {
-        method: 'POST',
-      });
-
-      this.deleteMsg = 'This review has been queued for deletion.';
-    } catch {
-      this.deleteMsg = 'Sorry, we were unable to delete this review.';
+    if (!this.reviewService) {
+      this.deleteMsg = msg('Sorry, we were unable to delete this review.');
+      return;
     }
+
+    const result = await this.reviewService.deleteReview({
+      identifier: this.identifier,
+      reviewer: this.review.reviewer,
+      reviewerItemname: this.review.reviewer_itemname,
+    });
+
+    this.deleteMsg = result.success
+      ? msg('This review has been queued for deletion.')
+      : (result.error ?? msg('Sorry, we were unable to delete this review.'));
   }
 
   static get styles(): CSSResultGroup {

--- a/src/services/review-service-interface.ts
+++ b/src/services/review-service-interface.ts
@@ -1,0 +1,48 @@
+/** A review the patron is submitting, before it's mapped onto wire field names */
+export type ReviewSubmission = {
+  /** The IA item being reviewed */
+  identifier: string;
+
+  /** Review subject */
+  title: string;
+
+  /** Review body */
+  body: string;
+
+  /** Star rating, '0' for no rating */
+  stars?: string;
+
+  /** ReCaptcha response, when the form ran a challenge */
+  recaptchaToken?: string;
+};
+
+/** The review to remove, identified by its reviewer */
+export type ReviewDeletion = {
+  /** The IA item the review belongs to */
+  identifier: string;
+
+  /** Reviewer screenname */
+  reviewer: string;
+
+  /** Reviewer itemname, used when the reviewer's account is gone */
+  reviewerItemname?: string;
+};
+
+/** The outcome of a review write or delete */
+export type ReviewServiceResult = {
+  success: boolean;
+
+  /** A message to show the patron, present when success is false */
+  error?: string;
+};
+
+/**
+ * Handles the network side of reviews, so the components only render state.
+ */
+export interface ReviewServiceInterface {
+  /** Add or update the patron's own review of an item */
+  submitReview(submission: ReviewSubmission): Promise<ReviewServiceResult>;
+
+  /** Remove a review, which the backend allows only for review moderators */
+  deleteReview(deletion: ReviewDeletion): Promise<ReviewServiceResult>;
+}

--- a/src/services/review-service.ts
+++ b/src/services/review-service.ts
@@ -1,0 +1,159 @@
+import { IaFetchHandler } from '@internetarchive/fetch-handler-service';
+import type { FetchHandlerInterface } from '@internetarchive/fetch-handler-service';
+
+import type {
+  ReviewDeletion,
+  ReviewServiceInterface,
+  ReviewServiceResult,
+  ReviewSubmission,
+} from './review-service-interface';
+
+export type ReviewServiceOptions = {
+  /** Handles retries and, for consumers that configure it, the CSRF header */
+  fetchHandler?: FetchHandlerInterface;
+
+  /** Origin for the endpoints. Empty string keeps requests same-origin. */
+  baseHost?: string;
+
+  /** Path a review submission POSTs to */
+  submitPath?: string;
+
+  /** Path a review deletion goes to */
+  deletePath?: string;
+
+  /** Verb the delete endpoint expects */
+  deleteMethod?: 'POST' | 'DELETE';
+
+  /**
+   * CSRF token to send as `X-CSRF-Token`.
+   *
+   * Consumers whose fetch handler already attaches the header leave this unset.
+   */
+  csrfToken?: string;
+};
+
+/** The endpoints the legacy details page serves */
+const LEGACY_SUBMIT_PATH = '/write-review.php';
+const LEGACY_DELETE_PATH = '/edit-reviews.php';
+
+const GENERIC_ERROR = 'Sorry, something went wrong. Please try again later.';
+
+/**
+ * Talks to the archive.org review endpoints.
+ *
+ * Both operations send the CSRF token as an `X-CSRF-Token` header. Submission also repeats it in
+ * the `field_reviewtoken` body field, which is what the legacy `write-review.php` form post uses.
+ */
+export class ReviewService implements ReviewServiceInterface {
+  private fetchHandler: FetchHandlerInterface;
+
+  private baseHost: string;
+
+  private submitPath: string;
+
+  private deletePath: string;
+
+  private deleteMethod: 'POST' | 'DELETE';
+
+  private csrfToken?: string;
+
+  constructor(options?: ReviewServiceOptions) {
+    this.fetchHandler = options?.fetchHandler ?? new IaFetchHandler();
+    this.baseHost = options?.baseHost ?? 'https://archive.org';
+    this.submitPath = options?.submitPath ?? LEGACY_SUBMIT_PATH;
+    this.deletePath = options?.deletePath ?? LEGACY_DELETE_PATH;
+    this.deleteMethod = options?.deleteMethod ?? 'POST';
+    this.csrfToken = options?.csrfToken;
+  }
+
+  /** @inheritdoc */
+  async submitReview(
+    submission: ReviewSubmission,
+  ): Promise<ReviewServiceResult> {
+    const body = new URLSearchParams();
+    body.append('identifier', submission.identifier);
+    body.append('field_reviewtitle', submission.title);
+    body.append('field_reviewbody', submission.body);
+    body.append('field_stars', submission.stars ?? '0');
+
+    if (submission.recaptchaToken) {
+      body.append('g-recaptcha-response', submission.recaptchaToken);
+    }
+
+    // tells write-review.php the post came from the form rather than a direct visit
+    body.append('submitter', 'review-form');
+
+    // the legacy endpoint reads the token from this field when there's no header
+    if (this.csrfToken) body.append('field_reviewtoken', this.csrfToken);
+
+    return this.request(`${this.baseHost}${this.submitPath}`, {
+      method: 'POST',
+      body,
+    });
+  }
+
+  /** @inheritdoc */
+  async deleteReview(deletion: ReviewDeletion): Promise<ReviewServiceResult> {
+    const params = new URLSearchParams();
+    params.append('identifier', deletion.identifier);
+    params.append('deleteReviewer', deletion.reviewer);
+    if (deletion.reviewerItemname) {
+      params.append('deleteReviewerItemname', deletion.reviewerItemname);
+    }
+
+    const url = `${this.baseHost}${this.deletePath}?${params.toString()}`;
+
+    return this.request(url, { method: this.deleteMethod });
+  }
+
+  /**
+   * Sends a credentialed request and reads the `{ success, error }` result out of it.
+   */
+  private async request(
+    url: string,
+    init: { method: string; body?: BodyInit },
+  ): Promise<ReviewServiceResult> {
+    const headers: Record<string, string> = {};
+    if (this.csrfToken) headers['X-CSRF-Token'] = this.csrfToken;
+
+    try {
+      const response = await this.fetchHandler.fetch(url, {
+        method: init.method,
+        body: init.body,
+        credentials: 'include',
+        headers,
+      });
+
+      return await this.parseResult(response);
+    } catch (e) {
+      console.error('Review request failed', e);
+      return { success: false, error: GENERIC_ERROR };
+    }
+  }
+
+  /**
+   * Reads a result out of a response.
+   *
+   * The status decides the outcome, so a rejected request can't read as a success. A JSON body
+   * supplies the patron-facing message; the legacy delete endpoint answers with an HTML page
+   * instead, and there the status is all there is to go on.
+   */
+  private async parseResult(response: Response): Promise<ReviewServiceResult> {
+    let payload: ReviewServiceResult | undefined;
+    try {
+      payload = (await response.json()) as ReviewServiceResult;
+    } catch {
+      payload = undefined;
+    }
+
+    if (!response.ok) {
+      return { success: false, error: payload?.error ?? GENERIC_ERROR };
+    }
+
+    if (!payload) return { success: true };
+
+    if (payload.success) return { success: true };
+
+    return { success: false, error: payload.error ?? GENERIC_ERROR };
+  }
+}

--- a/src/services/review-service.ts
+++ b/src/services/review-service.ts
@@ -1,4 +1,5 @@
-import { IaFetchHandler } from '@internetarchive/fetch-handler-service';
+import { FetchHandler } from '@internetarchive/fetch-handler';
+import type { FetchHandlerInterface } from '@internetarchive/fetch-handler';
 
 import type {
   ReviewDeletion,
@@ -7,19 +8,15 @@ import type {
   ReviewSubmission,
 } from './review-service-interface';
 
-/**
- * The slice of a fetch handler this service uses.
- *
- * Narrow on purpose: consumers hand over whichever handler they already have, and there is more
- * than one `@internetarchive` package providing one.
- */
-export type ReviewFetchHandler = {
-  fetch(input: RequestInfo, init?: RequestInit): Promise<Response>;
-};
-
 export type ReviewServiceOptions = {
-  /** Handles retries and, for consumers that configure it, the CSRF header */
-  fetchHandler?: ReviewFetchHandler;
+  /**
+   * Handles retries and the CSRF token.
+   *
+   * Writing and deleting need a handler built with a `getCsrfToken` source, since that is what
+   * supplies the `X-CSRF-Token` header these endpoints require. The token resolves per request,
+   * so it doesn't have to be known when the service is constructed.
+   */
+  fetchHandler?: FetchHandlerInterface;
 
   /** Origin for the endpoints. Empty string keeps requests same-origin. */
   baseHost?: string;
@@ -32,13 +29,6 @@ export type ReviewServiceOptions = {
 
   /** Verb the delete endpoint expects */
   deleteMethod?: 'POST' | 'DELETE';
-
-  /**
-   * CSRF token to send as `X-CSRF-Token`.
-   *
-   * Consumers whose fetch handler already attaches the header leave this unset.
-   */
-  csrfToken?: string;
 };
 
 /** The endpoints the legacy details page serves */
@@ -50,11 +40,11 @@ const GENERIC_ERROR = 'Sorry, something went wrong. Please try again later.';
 /**
  * Talks to the archive.org review endpoints.
  *
- * Both operations send the CSRF token as an `X-CSRF-Token` header. Submission also repeats it in
- * the `field_reviewtoken` body field, which is what the legacy `write-review.php` form post uses.
+ * The CSRF token is left to the fetch handler: both operations opt into its automatic
+ * `X-CSRF-Token` header, which resolves the token per request.
  */
 export class ReviewService implements ReviewServiceInterface {
-  private fetchHandler: ReviewFetchHandler;
+  private fetchHandler: FetchHandlerInterface;
 
   private baseHost: string;
 
@@ -64,15 +54,12 @@ export class ReviewService implements ReviewServiceInterface {
 
   private deleteMethod: 'POST' | 'DELETE';
 
-  private csrfToken?: string;
-
   constructor(options?: ReviewServiceOptions) {
-    this.fetchHandler = options?.fetchHandler ?? new IaFetchHandler();
+    this.fetchHandler = options?.fetchHandler ?? new FetchHandler();
     this.baseHost = options?.baseHost ?? 'https://archive.org';
     this.submitPath = options?.submitPath ?? LEGACY_SUBMIT_PATH;
     this.deletePath = options?.deletePath ?? LEGACY_DELETE_PATH;
     this.deleteMethod = options?.deleteMethod ?? 'POST';
-    this.csrfToken = options?.csrfToken;
   }
 
   /** @inheritdoc */
@@ -91,9 +78,6 @@ export class ReviewService implements ReviewServiceInterface {
 
     // tells write-review.php the post came from the form rather than a direct visit
     body.append('submitter', 'review-form');
-
-    // the legacy endpoint reads the token from this field when there's no header
-    if (this.csrfToken) body.append('field_reviewtoken', this.csrfToken);
 
     return this.request(`${this.baseHost}${this.submitPath}`, {
       method: 'POST',
@@ -122,15 +106,14 @@ export class ReviewService implements ReviewServiceInterface {
     url: string,
     init: { method: string; body?: BodyInit },
   ): Promise<ReviewServiceResult> {
-    const headers: Record<string, string> = {};
-    if (this.csrfToken) headers['X-CSRF-Token'] = this.csrfToken;
-
     try {
       const response = await this.fetchHandler.fetch(url, {
-        method: init.method,
-        body: init.body,
-        credentials: 'include',
-        headers,
+        requestInit: {
+          method: init.method,
+          body: init.body,
+          credentials: 'include',
+        },
+        includeCsrfToken: true,
       });
 
       return await this.parseResult(response);

--- a/src/services/review-service.ts
+++ b/src/services/review-service.ts
@@ -1,5 +1,4 @@
 import { IaFetchHandler } from '@internetarchive/fetch-handler-service';
-import type { FetchHandlerInterface } from '@internetarchive/fetch-handler-service';
 
 import type {
   ReviewDeletion,
@@ -8,9 +7,19 @@ import type {
   ReviewSubmission,
 } from './review-service-interface';
 
+/**
+ * The slice of a fetch handler this service uses.
+ *
+ * Narrow on purpose: consumers hand over whichever handler they already have, and there is more
+ * than one `@internetarchive` package providing one.
+ */
+export type ReviewFetchHandler = {
+  fetch(input: RequestInfo, init?: RequestInit): Promise<Response>;
+};
+
 export type ReviewServiceOptions = {
   /** Handles retries and, for consumers that configure it, the CSRF header */
-  fetchHandler?: FetchHandlerInterface;
+  fetchHandler?: ReviewFetchHandler;
 
   /** Origin for the endpoints. Empty string keeps requests same-origin. */
   baseHost?: string;
@@ -45,7 +54,7 @@ const GENERIC_ERROR = 'Sorry, something went wrong. Please try again later.';
  * the `field_reviewtoken` body field, which is what the legacy `write-review.php` form post uses.
  */
 export class ReviewService implements ReviewServiceInterface {
-  private fetchHandler: FetchHandlerInterface;
+  private fetchHandler: ReviewFetchHandler;
 
   private baseHost: string;
 

--- a/test/mocks/mock-fetch-handler.ts
+++ b/test/mocks/mock-fetch-handler.ts
@@ -1,6 +1,22 @@
 import type { FetchHandlerInterface } from '@internetarchive/fetch-handler-service/dist/src/fetch-handler-interface';
 
+/** A fetch() call the service made */
+export type RecordedFetch = {
+  url: string;
+  init?: RequestInit;
+};
+
 export class MockFetchHandler implements FetchHandlerInterface {
+  /** Every fetch() the service made, in order */
+  fetches: RecordedFetch[] = [];
+
+  /** What fetch() should hand back. Defaults to a 200 carrying `{ success: true }`. */
+  response: () => Response = () =>
+    new Response(JSON.stringify({ success: true }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+
   async fetchApiResponse<T>(): Promise<T> {
     return { success: true } as T;
   }
@@ -9,7 +25,27 @@ export class MockFetchHandler implements FetchHandlerInterface {
     return {} as T;
   }
 
-  async fetch(): Promise<Response> {
-    return new Response();
+  async fetch(input: RequestInfo, init?: RequestInit): Promise<Response> {
+    this.fetches.push({ url: input as string, init });
+    return this.response();
+  }
+
+  /** The single fetch the service made */
+  get lastFetch(): RecordedFetch {
+    return this.fetches[this.fetches.length - 1];
+  }
+
+  /** Header value off the last fetch, whatever shape the headers were passed in */
+  headerOnLastFetch(name: string): string | undefined {
+    const headers = this.lastFetch?.init?.headers as
+      | Record<string, string>
+      | undefined;
+    if (!headers) return undefined;
+    return new Headers(headers).get(name) ?? undefined;
+  }
+
+  /** Body of the last fetch, decoded as url-encoded form params */
+  bodyOnLastFetch(): URLSearchParams {
+    return new URLSearchParams(String(this.lastFetch?.init?.body ?? ''));
   }
 }

--- a/test/mocks/mock-fetch-handler.ts
+++ b/test/mocks/mock-fetch-handler.ts
@@ -1,9 +1,12 @@
-import type { FetchHandlerInterface } from '@internetarchive/fetch-handler-service/dist/src/fetch-handler-interface';
+import type {
+  FetchHandlerInterface,
+  FetchOptions,
+} from '@internetarchive/fetch-handler';
 
 /** A fetch() call the service made */
 export type RecordedFetch = {
   url: string;
-  init?: RequestInit;
+  options?: FetchOptions;
 };
 
 export class MockFetchHandler implements FetchHandlerInterface {
@@ -21,12 +24,19 @@ export class MockFetchHandler implements FetchHandlerInterface {
     return { success: true } as T;
   }
 
+  async fetchApiPathResponse<T>(): Promise<T> {
+    return { success: true } as T;
+  }
+
   async fetchIAApiResponse<T>(): Promise<T> {
     return {} as T;
   }
 
-  async fetch(input: RequestInfo, init?: RequestInit): Promise<Response> {
-    this.fetches.push({ url: input as string, init });
+  async fetch(input: RequestInfo, options?: unknown): Promise<Response> {
+    this.fetches.push({
+      url: input as string,
+      options: options as FetchOptions,
+    });
     return this.response();
   }
 
@@ -35,17 +45,18 @@ export class MockFetchHandler implements FetchHandlerInterface {
     return this.fetches[this.fetches.length - 1];
   }
 
-  /** Header value off the last fetch, whatever shape the headers were passed in */
-  headerOnLastFetch(name: string): string | undefined {
-    const headers = this.lastFetch?.init?.headers as
-      | Record<string, string>
-      | undefined;
-    if (!headers) return undefined;
-    return new Headers(headers).get(name) ?? undefined;
+  /** The RequestInit the service handed to the handler */
+  get lastRequestInit(): RequestInit {
+    return this.lastFetch?.options?.requestInit ?? {};
+  }
+
+  /** Whether the last fetch opted into the handler's CSRF header */
+  get lastIncludedCsrfToken(): boolean | undefined {
+    return this.lastFetch?.options?.includeCsrfToken;
   }
 
   /** Body of the last fetch, decoded as url-encoded form params */
   bodyOnLastFetch(): URLSearchParams {
-    return new URLSearchParams(String(this.lastFetch?.init?.body ?? ''));
+    return new URLSearchParams(String(this.lastRequestInit.body ?? ''));
   }
 }

--- a/test/mocks/mock-review-service.ts
+++ b/test/mocks/mock-review-service.ts
@@ -1,0 +1,29 @@
+import type {
+  ReviewDeletion,
+  ReviewServiceInterface,
+  ReviewServiceResult,
+  ReviewSubmission,
+} from '../../src/services/review-service-interface';
+
+export class MockReviewService implements ReviewServiceInterface {
+  /** Submissions the form handed over, in order */
+  submissions: ReviewSubmission[] = [];
+
+  /** Deletions the review handed over, in order */
+  deletions: ReviewDeletion[] = [];
+
+  /** What both operations report back */
+  result: ReviewServiceResult = { success: true };
+
+  async submitReview(
+    submission: ReviewSubmission,
+  ): Promise<ReviewServiceResult> {
+    this.submissions.push(submission);
+    return this.result;
+  }
+
+  async deleteReview(deletion: ReviewDeletion): Promise<ReviewServiceResult> {
+    this.deletions.push(deletion);
+    return this.result;
+  }
+}

--- a/test/review-form.test.ts
+++ b/test/review-form.test.ts
@@ -1,9 +1,9 @@
-import { html, fixture, expect } from '@open-wc/testing';
+import { html, fixture, expect, waitUntil } from '@open-wc/testing';
 
 import type { ReviewForm } from '../src/review-form';
 import { Review } from '@internetarchive/metadata-service';
 import '../src/review-form';
-import { MockFetchHandler } from './mocks/mock-fetch-handler';
+import { MockReviewService } from './mocks/mock-review-service';
 
 const mockOldReview = new Review({
   stars: 5,
@@ -14,8 +14,6 @@ const mockOldReview = new Review({
   createdate: new Date('02/07/2025'),
   reviewer_itemname: '@foo-bar',
 });
-
-const mockFetchHandler = new MockFetchHandler();
 
 describe('ReviewForm', () => {
   it('passes the a11y audit', async () => {
@@ -299,35 +297,83 @@ describe('ReviewForm', () => {
     expect(starsInput?.value).to.equal('0');
   });
 
-  it('prefills the identifier if provided', async () => {
+  it('hands the identifier and the edited fields to the review service', async () => {
+    const reviewService = new MockReviewService();
     const el = await fixture<ReviewForm>(
-      html`<ia-review-form .identifier=${'foo'}></ia-review-form>`,
+      html`<ia-review-form
+        .identifier=${'foo'}
+        .oldReview=${mockOldReview}
+        .reviewService=${reviewService}
+        ?bypassRecaptcha=${true}
+      ></ia-review-form>`,
     );
 
-    const identifierInput = el.shadowRoot?.querySelector(
-      'input[name="identifier"]',
-    ) as HTMLInputElement;
-    expect(identifierInput).to.exist;
-    expect(identifierInput.value).to.equal('foo');
+    (
+      el.shadowRoot?.querySelector('button[name="submit"]') as HTMLButtonElement
+    )?.click();
+    await el.updateComplete;
+
+    expect(reviewService.submissions.length).to.equal(1);
+    expect(reviewService.submissions[0]).to.deep.equal({
+      identifier: 'foo',
+      title: 'What a cool book!',
+      body: 'I loved it.',
+      stars: '5',
+      recaptchaToken: undefined,
+    });
   });
 
-  it('prefills the token if provided', async () => {
+  it('shows an error on submit if it has no review service', async () => {
     const el = await fixture<ReviewForm>(
-      html`<ia-review-form .token=${'12345a'}></ia-review-form>`,
+      html`<ia-review-form
+        .identifier=${'foo'}
+        .oldReview=${mockOldReview}
+        ?bypassRecaptcha=${true}
+      ></ia-review-form>`,
     );
 
-    const tokenInput = el.shadowRoot?.querySelector(
-      'input[name="field_reviewtoken"]',
-    ) as HTMLInputElement;
-    expect(tokenInput).to.exist;
-    expect(tokenInput.value).to.equal('12345a');
+    (
+      el.shadowRoot?.querySelector('button[name="submit"]') as HTMLButtonElement
+    )?.click();
+    await el.updateComplete;
+
+    const errorDiv = el.shadowRoot?.querySelector(
+      '.recoverable-error',
+    ) as HTMLDivElement;
+    expect(errorDiv).to.exist;
+  });
+
+  it('surfaces the error the review service reports', async () => {
+    const reviewService = new MockReviewService();
+    reviewService.result = { success: false, error: 'Reviews are frozen.' };
+    const el = await fixture<ReviewForm>(
+      html`<ia-review-form
+        .identifier=${'foo'}
+        .oldReview=${mockOldReview}
+        .reviewService=${reviewService}
+        ?bypassRecaptcha=${true}
+      ></ia-review-form>`,
+    );
+
+    (
+      el.shadowRoot?.querySelector('button[name="submit"]') as HTMLButtonElement
+    )?.click();
+
+    // the service call resolves a microtask later, so the error needs waiting for
+    await waitUntil(() => el.shadowRoot?.querySelector('.recoverable-error'));
+
+    const errorDiv = el.shadowRoot?.querySelector(
+      '.recoverable-error',
+    ) as HTMLDivElement;
+    expect(errorDiv?.textContent).to.contain('Reviews are frozen.');
   });
 
   it('shows an error on submit if no recaptcha manager/widget is provided', async () => {
     const el = await fixture<ReviewForm>(
       html`<ia-review-form
+        .identifier=${'foo'}
         .oldReview=${mockOldReview}
-        .fetchHandler=${mockFetchHandler}
+        .reviewService=${new MockReviewService()}
       ></ia-review-form>`,
     );
 
@@ -351,11 +397,10 @@ describe('ReviewForm', () => {
   it('skips recaptcha if the bypass switch is activated', async () => {
     const el = await fixture<ReviewForm>(
       html`<ia-review-form
+        .identifier=${'foo'}
         .oldReview=${mockOldReview}
-        .fetchHandler=${mockFetchHandler}
+        .reviewService=${new MockReviewService()}
         ?bypassRecaptcha=${true}
-        .baseHost=${'#'}
-        .endpointPath=${'#'}
       ></ia-review-form>`,
     );
 
@@ -376,11 +421,10 @@ describe('ReviewForm', () => {
   it('skips recaptcha if the bypass switch is activated, even with recaptcha manager', async () => {
     const el = await fixture<ReviewForm>(
       html`<ia-review-form
+        .identifier=${'foo'}
         .oldReview=${mockOldReview}
-        .fetchHandler=${mockFetchHandler}
+        .reviewService=${new MockReviewService()}
         ?bypassRecaptcha=${true}
-        .baseHost=${'#'}
-        .endpointPath=${'#'}
       ></ia-review-form>`,
     );
 

--- a/test/services/review-service.test.ts
+++ b/test/services/review-service.test.ts
@@ -24,35 +24,25 @@ const jsonResponse = (body: unknown, status = 200) =>
 
 describe('ReviewService', () => {
   describe('submitReview', () => {
-    it('sends the CSRF token as an X-CSRF-Token header', async () => {
-      const fetchHandler = new MockFetchHandler();
-      const service = new ReviewService({ fetchHandler, csrfToken: 'tok123' });
-
-      await service.submitReview(submission);
-
-      expect(fetchHandler.headerOnLastFetch('X-CSRF-Token')).to.equal('tok123');
-    });
-
-    it('also sends the token as field_reviewtoken for the legacy endpoint', async () => {
-      const fetchHandler = new MockFetchHandler();
-      const service = new ReviewService({ fetchHandler, csrfToken: 'tok123' });
-
-      await service.submitReview(submission);
-
-      expect(fetchHandler.bodyOnLastFetch().get('field_reviewtoken')).to.equal(
-        'tok123',
-      );
-    });
-
-    it('omits the token entirely when it has none, leaving it to the fetch handler', async () => {
+    it('opts into the fetch handler CSRF header', async () => {
       const fetchHandler = new MockFetchHandler();
       const service = new ReviewService({ fetchHandler });
 
       await service.submitReview(submission);
 
-      expect(fetchHandler.headerOnLastFetch('X-CSRF-Token')).to.be.undefined;
+      expect(fetchHandler.lastIncludedCsrfToken).to.be.true;
+    });
+
+    it('carries no token of its own, so the handler resolves it per request', async () => {
+      const fetchHandler = new MockFetchHandler();
+      const service = new ReviewService({ fetchHandler });
+
+      await service.submitReview(submission);
+
       expect(fetchHandler.bodyOnLastFetch().get('field_reviewtoken')).to.be
         .null;
+      const headers = fetchHandler.lastRequestInit.headers;
+      expect(headers).to.be.undefined;
     });
 
     it('maps the submission onto the wire field names', async () => {
@@ -98,8 +88,8 @@ describe('ReviewService', () => {
       expect(fetchHandler.lastFetch.url).to.equal(
         'https://example.archive.org/services/offshoot/details-page/review.php',
       );
-      expect(fetchHandler.lastFetch.init?.method).to.equal('POST');
-      expect(fetchHandler.lastFetch.init?.credentials).to.equal('include');
+      expect(fetchHandler.lastRequestInit.method).to.equal('POST');
+      expect(fetchHandler.lastRequestInit.credentials).to.equal('include');
     });
 
     it('defaults to the legacy write endpoint', async () => {
@@ -140,13 +130,12 @@ describe('ReviewService', () => {
   describe('deleteReview', () => {
     it('keeps the CSRF token out of the query string', async () => {
       const fetchHandler = new MockFetchHandler();
-      const service = new ReviewService({ fetchHandler, csrfToken: 'tok123' });
+      const service = new ReviewService({ fetchHandler });
 
       await service.deleteReview(deletion);
 
-      expect(fetchHandler.lastFetch.url).to.not.contain('tok123');
       expect(fetchHandler.lastFetch.url).to.not.contain('csrf_token');
-      expect(fetchHandler.headerOnLastFetch('X-CSRF-Token')).to.equal('tok123');
+      expect(fetchHandler.lastIncludedCsrfToken).to.be.true;
     });
 
     it('sends credentials', async () => {
@@ -155,7 +144,7 @@ describe('ReviewService', () => {
 
       await service.deleteReview(deletion);
 
-      expect(fetchHandler.lastFetch.init?.credentials).to.equal('include');
+      expect(fetchHandler.lastRequestInit.credentials).to.equal('include');
     });
 
     it('identifies the review by reviewer in the query string', async () => {
@@ -190,7 +179,7 @@ describe('ReviewService', () => {
       await service.deleteReview(deletion);
 
       expect(fetchHandler.lastFetch.url).to.contain('/edit-reviews.php');
-      expect(fetchHandler.lastFetch.init?.method).to.equal('POST');
+      expect(fetchHandler.lastRequestInit.method).to.equal('POST');
     });
 
     it('uses the configured verb and path', async () => {
@@ -207,7 +196,7 @@ describe('ReviewService', () => {
       expect(fetchHandler.lastFetch.url).to.contain(
         '/services/offshoot/details-page/review.php',
       );
-      expect(fetchHandler.lastFetch.init?.method).to.equal('DELETE');
+      expect(fetchHandler.lastRequestInit.method).to.equal('DELETE');
     });
 
     it('reports failure when the server rejects the request', async () => {

--- a/test/services/review-service.test.ts
+++ b/test/services/review-service.test.ts
@@ -1,0 +1,251 @@
+import { expect } from '@open-wc/testing';
+
+import { ReviewService } from '../../src/services/review-service';
+import { MockFetchHandler } from '../mocks/mock-fetch-handler';
+
+const submission = {
+  identifier: 'foo',
+  title: 'Great',
+  body: 'Really great.',
+  stars: '5',
+};
+
+const deletion = {
+  identifier: 'foo',
+  reviewer: 'Joe Blow',
+  reviewerItemname: '@joe',
+};
+
+const jsonResponse = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+describe('ReviewService', () => {
+  describe('submitReview', () => {
+    it('sends the CSRF token as an X-CSRF-Token header', async () => {
+      const fetchHandler = new MockFetchHandler();
+      const service = new ReviewService({ fetchHandler, csrfToken: 'tok123' });
+
+      await service.submitReview(submission);
+
+      expect(fetchHandler.headerOnLastFetch('X-CSRF-Token')).to.equal('tok123');
+    });
+
+    it('also sends the token as field_reviewtoken for the legacy endpoint', async () => {
+      const fetchHandler = new MockFetchHandler();
+      const service = new ReviewService({ fetchHandler, csrfToken: 'tok123' });
+
+      await service.submitReview(submission);
+
+      expect(fetchHandler.bodyOnLastFetch().get('field_reviewtoken')).to.equal(
+        'tok123',
+      );
+    });
+
+    it('omits the token entirely when it has none, leaving it to the fetch handler', async () => {
+      const fetchHandler = new MockFetchHandler();
+      const service = new ReviewService({ fetchHandler });
+
+      await service.submitReview(submission);
+
+      expect(fetchHandler.headerOnLastFetch('X-CSRF-Token')).to.be.undefined;
+      expect(fetchHandler.bodyOnLastFetch().get('field_reviewtoken')).to.be
+        .null;
+    });
+
+    it('maps the submission onto the wire field names', async () => {
+      const fetchHandler = new MockFetchHandler();
+      const service = new ReviewService({ fetchHandler });
+
+      await service.submitReview({ ...submission, recaptchaToken: 'rc' });
+
+      const body = fetchHandler.bodyOnLastFetch();
+      expect(body.get('identifier')).to.equal('foo');
+      expect(body.get('field_reviewtitle')).to.equal('Great');
+      expect(body.get('field_reviewbody')).to.equal('Really great.');
+      expect(body.get('field_stars')).to.equal('5');
+      expect(body.get('g-recaptcha-response')).to.equal('rc');
+      expect(body.get('submitter')).to.equal('review-form');
+    });
+
+    it('defaults stars to 0 and omits an absent recaptcha token', async () => {
+      const fetchHandler = new MockFetchHandler();
+      const service = new ReviewService({ fetchHandler });
+
+      await service.submitReview({
+        identifier: 'foo',
+        title: 'Great',
+        body: 'Really great.',
+      });
+
+      const body = fetchHandler.bodyOnLastFetch();
+      expect(body.get('field_stars')).to.equal('0');
+      expect(body.get('g-recaptcha-response')).to.be.null;
+    });
+
+    it('sends credentials and posts to the configured endpoint', async () => {
+      const fetchHandler = new MockFetchHandler();
+      const service = new ReviewService({
+        fetchHandler,
+        baseHost: 'https://example.archive.org',
+        submitPath: '/services/offshoot/details-page/review.php',
+      });
+
+      await service.submitReview(submission);
+
+      expect(fetchHandler.lastFetch.url).to.equal(
+        'https://example.archive.org/services/offshoot/details-page/review.php',
+      );
+      expect(fetchHandler.lastFetch.init?.method).to.equal('POST');
+      expect(fetchHandler.lastFetch.init?.credentials).to.equal('include');
+    });
+
+    it('defaults to the legacy write endpoint', async () => {
+      const fetchHandler = new MockFetchHandler();
+      const service = new ReviewService({ fetchHandler, baseHost: '' });
+
+      await service.submitReview(submission);
+
+      expect(fetchHandler.lastFetch.url).to.equal('/write-review.php');
+    });
+
+    it('reports the error message the backend supplies', async () => {
+      const fetchHandler = new MockFetchHandler();
+      fetchHandler.response = () =>
+        jsonResponse({ success: false, error: 'Reviews are not allowed.' });
+      const service = new ReviewService({ fetchHandler });
+
+      const result = await service.submitReview(submission);
+
+      expect(result.success).to.be.false;
+      expect(result.error).to.equal('Reviews are not allowed.');
+    });
+
+    it('reports failure when the request throws', async () => {
+      const fetchHandler = new MockFetchHandler();
+      fetchHandler.response = () => {
+        throw new Error('network down');
+      };
+      const service = new ReviewService({ fetchHandler });
+
+      const result = await service.submitReview(submission);
+
+      expect(result.success).to.be.false;
+      expect(result.error).to.exist;
+    });
+  });
+
+  describe('deleteReview', () => {
+    it('keeps the CSRF token out of the query string', async () => {
+      const fetchHandler = new MockFetchHandler();
+      const service = new ReviewService({ fetchHandler, csrfToken: 'tok123' });
+
+      await service.deleteReview(deletion);
+
+      expect(fetchHandler.lastFetch.url).to.not.contain('tok123');
+      expect(fetchHandler.lastFetch.url).to.not.contain('csrf_token');
+      expect(fetchHandler.headerOnLastFetch('X-CSRF-Token')).to.equal('tok123');
+    });
+
+    it('sends credentials', async () => {
+      const fetchHandler = new MockFetchHandler();
+      const service = new ReviewService({ fetchHandler });
+
+      await service.deleteReview(deletion);
+
+      expect(fetchHandler.lastFetch.init?.credentials).to.equal('include');
+    });
+
+    it('identifies the review by reviewer in the query string', async () => {
+      const fetchHandler = new MockFetchHandler();
+      const service = new ReviewService({ fetchHandler, baseHost: '' });
+
+      await service.deleteReview(deletion);
+
+      const query = new URLSearchParams(
+        fetchHandler.lastFetch.url.split('?')[1],
+      );
+      expect(query.get('identifier')).to.equal('foo');
+      expect(query.get('deleteReviewer')).to.equal('Joe Blow');
+      expect(query.get('deleteReviewerItemname')).to.equal('@joe');
+    });
+
+    it('omits the reviewer itemname when there is none', async () => {
+      const fetchHandler = new MockFetchHandler();
+      const service = new ReviewService({ fetchHandler, baseHost: '' });
+
+      await service.deleteReview({ identifier: 'foo', reviewer: 'Joe Blow' });
+
+      expect(fetchHandler.lastFetch.url).to.not.contain(
+        'deleteReviewerItemname',
+      );
+    });
+
+    it('posts to the legacy endpoint by default', async () => {
+      const fetchHandler = new MockFetchHandler();
+      const service = new ReviewService({ fetchHandler, baseHost: '' });
+
+      await service.deleteReview(deletion);
+
+      expect(fetchHandler.lastFetch.url).to.contain('/edit-reviews.php');
+      expect(fetchHandler.lastFetch.init?.method).to.equal('POST');
+    });
+
+    it('uses the configured verb and path', async () => {
+      const fetchHandler = new MockFetchHandler();
+      const service = new ReviewService({
+        fetchHandler,
+        baseHost: '',
+        deletePath: '/services/offshoot/details-page/review.php',
+        deleteMethod: 'DELETE',
+      });
+
+      await service.deleteReview(deletion);
+
+      expect(fetchHandler.lastFetch.url).to.contain(
+        '/services/offshoot/details-page/review.php',
+      );
+      expect(fetchHandler.lastFetch.init?.method).to.equal('DELETE');
+    });
+
+    it('reports failure when the server rejects the request', async () => {
+      const fetchHandler = new MockFetchHandler();
+      fetchHandler.response = () =>
+        jsonResponse(
+          { success: false, error: 'You must be logged in to edit reviews' },
+          401,
+        );
+      const service = new ReviewService({ fetchHandler });
+
+      const result = await service.deleteReview(deletion);
+
+      expect(result.success).to.be.false;
+      expect(result.error).to.equal('You must be logged in to edit reviews');
+    });
+
+    it('reports failure on a non-2xx with no JSON body', async () => {
+      const fetchHandler = new MockFetchHandler();
+      fetchHandler.response = () =>
+        new Response('<html>nope</html>', { status: 500 });
+      const service = new ReviewService({ fetchHandler });
+
+      const result = await service.deleteReview(deletion);
+
+      expect(result.success).to.be.false;
+      expect(result.error).to.exist;
+    });
+
+    it('treats an HTML 200 from the legacy endpoint as success', async () => {
+      const fetchHandler = new MockFetchHandler();
+      fetchHandler.response = () =>
+        new Response('<html>queued</html>', { status: 200 });
+      const service = new ReviewService({ fetchHandler });
+
+      const result = await service.deleteReview(deletion);
+
+      expect(result.success).to.be.true;
+    });
+  });
+});


### PR DESCRIPTION
`review-form.ts` knew `baseHost` + `endpointPath` and parsed the response shape itself; `review.ts` built a delete URL and called `fetch()` directly. Both now hand a typed object to a `ReviewService` and just render what comes back.

- Token goes out as an `X-CSRF-Token` header. Submission still repeats it in `field_reviewtoken` for the no-JS form post. Delete no longer puts it in the query string.
- Delete gets `credentials: 'include'` and a real `response.ok` check, so a rejected delete stops reporting success (the bug Isa flagged on offshoot !1131).
- `ia-reviews` builds a default service from `baseHost` / `endpointPath` / `token` when none is injected, so the attribute-only legacy details page keeps working.

Petabox side is ia/petabox!6435. Offshoot pins `1.1.0-webdev-8840.0` while this is in review.

Heads up on the version: `ia-review-form` and `ia-review` lost their `token` / `baseHost` / `endpointPath` / `csrfToken` props, so if anyone uses those two directly this is a major, not a minor. `ia-reviews` itself is backward compatible.